### PR TITLE
[feat] 토스트 메시지 구현

### DIFF
--- a/Melon_iOS/Melon_iOS/Global/Components/ToastMessage.swift
+++ b/Melon_iOS/Melon_iOS/Global/Components/ToastMessage.swift
@@ -13,10 +13,11 @@ import Then
 final class ToastMessage: UIView {
  
   // MARK: - Properties
-  //변수
+  
   private var action: (() -> Void)?
   
   // MARK: - UI Components
+  
   private lazy var messageLabel = UILabel().then {
     $0.text = "믹스업에 추가되었어요"
     $0.textColor = .white
@@ -31,6 +32,7 @@ final class ToastMessage: UIView {
   }
 
   // MARK: - Lifecycle
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     setUI()
@@ -42,12 +44,13 @@ final class ToastMessage: UIView {
   }
 
   // MARK: - Setup Methods
+  
   func setUI() {
     backgroundColor = .neonpink
     layer.cornerRadius = 8
     clipsToBounds = true
     
-    self.addSubviews(messageLabel, actionButton)
+    addSubviews(messageLabel, actionButton)
   }
   
   func setLayout() {
@@ -59,7 +62,7 @@ final class ToastMessage: UIView {
     
     actionButton.snp.makeConstraints {
       $0.centerY.equalToSuperview()
-      $0.trailing.equalToSuperview().offset(-16)
+      $0.trailing.equalToSuperview().inset(16)
       $0.width.equalTo(25)
       $0.height.equalTo(21)
     }
@@ -69,7 +72,7 @@ final class ToastMessage: UIView {
     self.snp.makeConstraints {
       $0.height.equalTo(49)
       $0.horizontalEdges.equalToSuperview().inset(16)
-      $0.bottom.equalToSuperview().offset(-156)
+      $0.bottom.equalToSuperview().inset(78)
     }
     dissmissToastMessage()
   }
@@ -79,11 +82,13 @@ final class ToastMessage: UIView {
   }
 
   // MARK: - Actions
+  
   @objc func actionButtonTapped() {
     action?()
   }
 
   // MARK: - Private Methods
+  
   private func dissmissToastMessage() {
     DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
       UIView.animate(withDuration: 0.3, animations: {

--- a/Melon_iOS/Melon_iOS/Global/Components/ToastMessage.swift
+++ b/Melon_iOS/Melon_iOS/Global/Components/ToastMessage.swift
@@ -1,0 +1,97 @@
+//
+//  ToastMessage.swift
+//  Melon_iOS
+//
+//  Created by 이승준 on 11/17/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ToastMessage: UIView {
+ 
+  // MARK: - Properties
+  //변수
+  private var action: (() -> Void)?
+  
+  // MARK: - UI Components
+  private lazy var messageLabel = UILabel().then {
+    $0.text = "믹스업에 추가되었어요"
+    $0.textColor = .white
+    $0.font = UIFont.pretendard(.body_m_14)
+  }
+  
+  private lazy var actionButton = UIButton().then {
+    $0.setTitle("이동", for: .normal)
+    $0.setTitleColor(.white, for: .normal)
+    $0.titleLabel?.font = UIFont.pretendard(.body_m_14)
+    $0.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
+  }
+
+  // MARK: - Lifecycle
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setUI()
+    setLayout()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Setup Methods
+  func setUI() {
+    backgroundColor = .neonpink
+    layer.cornerRadius = 8
+    clipsToBounds = true
+    
+    self.addSubviews(messageLabel, actionButton)
+  }
+  
+  func setLayout() {
+    
+    messageLabel.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.leading.equalToSuperview().offset(16)
+    }
+    
+    actionButton.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().offset(-16)
+      $0.width.equalTo(25)
+      $0.height.equalTo(21)
+    }
+  }
+  
+  func show() {
+    self.snp.makeConstraints {
+      $0.height.equalTo(49)
+      $0.horizontalEdges.equalToSuperview().inset(16)
+      $0.bottom.equalToSuperview().offset(-156)
+    }
+    dissmissToastMessage()
+  }
+  
+  func configure(action: (() -> Void)? = nil) {
+    self.action = action
+  }
+
+  // MARK: - Actions
+  @objc func actionButtonTapped() {
+    action?()
+  }
+
+  // MARK: - Private Methods
+  private func dissmissToastMessage() {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+      UIView.animate(withDuration: 0.3, animations: {
+        self.alpha = 0
+      }) { _ in
+        self.removeFromSuperview()
+      }
+    }
+  }
+  
+}


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #16 

---

## 📎 Work Description 
- 토스트 메시지 UI 구현했습니다
- 토스트 메시지가 나타나고 3초 뒤에 사라지도록 구현했습니다.

---

## 🧪 How To Use
`UIViewController` 에서 토스트 메시지를 사용하기 위해 해주어야 하는 작업
1. 토스트 메시지 인스턴스 생성
2. view에 추가
3. 토스트 메시지의 "이동" 버튼을 눌렀을 때 동작할 클로저 설정 (‼️필수!!)
4. show() 함수를 호출하여 3초간 나타나게 하기

```swift
button.addTarget(self, action: #selector(showToast), for: .touchUpInside)

@objc func showToast() {
  let toast = ToastMessage()
  self.view.addSubview(toast)
  toast.configure(action: {
    print("toast message action button tapped")
  })
  toast.show()
}
```

---

## 🧐  Idea

> 어차피 "이동" 버튼의 동작은 하나인데, 그냥 UIViewController를 받아서 바로 "믹서"로 이동하는 함수를 ToastMessage 내에서 지정하면 되는거 아님?

- MVC 패턴
UIView와 UIViewController의 책임을 분리해야한다. UIView내에서 UIViewController의 역할까지 수행하면 코드 일관성이 사라지게 된다.

- 확장성 감소
합세라 그럴 일은 없지만, 추후 다른 동작을 지정해야 하는 등의 확장성이 감소하게 된다.

---

## 📷 Screenshots  

| 기능/화면 | iPhone 16 Pro |
|:---------:|:--------------:|
| A 기능 | ![ToastMessage](https://github.com/user-attachments/assets/ced8ee7a-1149-4433-a83b-ca1f7268f61e) |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
