### PR TITLE
[Feat] Home API

### DIFF
--- a/Melon_iOS/HomeAPI.swift
+++ b/Melon_iOS/HomeAPI.swift
@@ -1,8 +1,0 @@
-//
-//  HomeAPI.swift
-//  Melon_iOS
-//
-//  Created by 이승준 on 11/24/25.
-//
-
-import Foundation

--- a/Melon_iOS/HomeAPI.swift
+++ b/Melon_iOS/HomeAPI.swift
@@ -1,0 +1,8 @@
+//
+//  HomeAPI.swift
+//  Melon_iOS
+//
+//  Created by 이승준 on 11/24/25.
+//
+
+import Foundation

--- a/Melon_iOS/Melon_iOS/Application/SceneDelegate.swift
+++ b/Melon_iOS/Melon_iOS/Application/SceneDelegate.swift
@@ -18,7 +18,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
 
         let rootVC = TabBarController()
-        let nav = UINavigationController(rootViewController: rootVC)
+        let nav = UINavigationController(rootViewController: rootVC).then {
+            $0.isNavigationBarHidden = true
+        }
 
         window.rootViewController = nav
 

--- a/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
+++ b/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
@@ -45,7 +45,7 @@ extension HomeAPI: BaseTargetType {
             } else {
                 return .requestParameters(
                     parameters: ["category": area.rawValue],
-                    encoding: URLEncoding.default // 또는 queryString
+                    encoding: URLEncoding.default
                 )
             }
         }

--- a/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
+++ b/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
@@ -9,10 +9,11 @@ import Foundation
 import Moya
 
 enum HomeAPI {
-    case fetchPopular, fetchChart, fetchNewest(NewestArea?)
+    case fetchPopular, fetchChart, fetchNewest(NewestArea)
 }
 
 enum NewestArea: String {
+    case all
     case kor = "KOR"
     case int = "INT"
 }
@@ -23,13 +24,10 @@ extension HomeAPI: BaseTargetType {
         switch self {
         case .fetchPopular:
             return "/api/v1/music/popular"
+        case .fetchNewest:
+            return "/api/v1/music/newest"
         case .fetchChart:
-            return "/api/v1/chart/chart"
-        case .fetchNewest(let area):
-            guard let area else {
-                return "/api/v1/music/newest"
-            }
-            return "/api/v1/music/newest?category=\(area.rawValue)"
+            return "/api/v1/music/chart"
         }
     }
 
@@ -38,6 +36,18 @@ extension HomeAPI: BaseTargetType {
     }
 
     var task: Task {
-        return .requestPlain
+        switch self {
+            case .fetchPopular, .fetchChart:
+            return .requestPlain
+        case .fetchNewest(let area):
+            if area == .all {
+                return .requestPlain
+            } else {
+                return .requestParameters(
+                    parameters: ["category": area.rawValue],
+                    encoding: URLEncoding.default // 또는 queryString
+                )
+            }
+        }
     }
 }

--- a/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
+++ b/Melon_iOS/Melon_iOS/Network/API/HomeAPI.swift
@@ -1,0 +1,43 @@
+//
+//  HomeAPI.swift
+//  Melon_iOS
+//
+//  Created by 이승준 on 11/24/25.
+//
+
+import Foundation
+import Moya
+
+enum HomeAPI {
+    case fetchPopular, fetchChart, fetchNewest(NewestArea?)
+}
+
+enum NewestArea: String {
+    case kor = "KOR"
+    case int = "INT"
+}
+
+extension HomeAPI: BaseTargetType {
+
+    var path: String {
+        switch self {
+        case .fetchPopular:
+            return "/api/v1/music/popular"
+        case .fetchChart:
+            return "/api/v1/chart/chart"
+        case .fetchNewest(let area):
+            guard let area else {
+                return "/api/v1/music/newest"
+            }
+            return "/api/v1/music/newest?category=\(area.rawValue)"
+        }
+    }
+
+    var method: Moya.Method {
+        return .get
+    }
+
+    var task: Task {
+        return .requestPlain
+    }
+}

--- a/Melon_iOS/Melon_iOS/Network/DTO/HomeDTO.swift
+++ b/Melon_iOS/Melon_iOS/Network/DTO/HomeDTO.swift
@@ -7,66 +7,91 @@
 
 import UIKit
 
-struct PopularSongDTO {
-  let title: String?
-  let artist: String?
-  let imageUrl: String?
-  let category: String?
-  
-  init(title: String = "", artist: String = "", imageUrl: String? = "", category: String = "") {
-    self.title = title
-    self.artist = artist
-    self.imageUrl = imageUrl
-    self.category = category
-  }
+struct PopularSongDTO: Decodable {
+    let id: Int?
+    let title: String?
+    let artistName: String?
+    let imageUrl: String?
+    let country: String?
+    
+    init(id: Int = -1,
+         title: String = "",
+         artistName: String = "",
+         imageUrl: String? = "",
+         country: String? = "",
+    ) {
+        self.id = id
+        self.title = title
+        self.artistName = artistName
+        self.imageUrl = imageUrl
+        self.country = country
+    }
 }
 
-struct LatestSongDTO {
-  let title: String?
-  let artist: String?
-  let imageUrl: String?
-  
-  init(title: String? = "", artist: String? = "", imageUrl: String? = "") {
-    self.title = title
-    self.artist = artist
-    self.imageUrl = imageUrl
-  }
+struct NewestSongDTO: Decodable {
+    let id: Int?
+    let title: String?
+    let artistName: String?
+    let imageUrl: String?
+    let country: String?
+    
+    init(id: Int = -1,
+         title: String = "",
+         artistName: String = "",
+         imageUrl: String? = "",
+         country: String? = "",
+    ) {
+        self.id = id
+        self.title = title
+        self.artistName = artistName
+        self.imageUrl = imageUrl
+        self.country = country
+    }
 }
 
-struct ChartSongDTO {
-  let title: String?
-  let artist: String?
-  let imageUrl: String?
-  
-  init(title: String = "", artist: String? = "", imageUrl: String? = "") {
-    self.title = title
-    self.artist = artist
-    self.imageUrl = imageUrl
-  }
+struct ChartSongDTO: Decodable {
+    let id: Int?
+    let title: String?
+    let artistName: String?
+    let imageUrl: String?
+    let country: String?
+    
+    init(id: Int = -1,
+         title: String = "",
+         artistName: String = "",
+         imageUrl: String? = "",
+         country: String? = "",
+    ) {
+        self.id = id
+        self.title = title
+        self.artistName = artistName
+        self.imageUrl = imageUrl
+        self.country = country
+    }
 }
 
 struct PreferencedSongDTO {
-  let title: String?
-  let artist: String?
-  let imageUrl: String?
-  
-  init(title: String? = "", artist: String? = "", imageUrl: String? = "") {
-    self.title = title
-    self.artist = artist
-    self.imageUrl = imageUrl
-  }
+    let title: String?
+    let artist: String?
+    let imageUrl: String?
+    
+    init(title: String? = "", artist: String? = "", imageUrl: String? = "") {
+        self.title = title
+        self.artist = artist
+        self.imageUrl = imageUrl
+    }
 }
 
 struct PersonalizedDTO {
-  let title: String
-  let image: UIImage
+    let title: String
+    let image: UIImage
 }
 
 struct BannerDTO {
-  let title: String
-  let subtitle: String
-  let promotion: String
-  let capsuleTitle: String
-  let image: UIImage?
-  let backgroundColor: UIColor
+    let title: String
+    let subtitle: String
+    let promotion: String
+    let capsuleTitle: String
+    let image: UIImage?
+    let backgroundColor: UIColor
 }

--- a/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
@@ -26,7 +26,7 @@ final class HomeService {
         }
     }
     
-    func fetchNewestSongs(area: NewestArea? = nil) async throws -> [NewestSongDTO] {
+    func fetchNewestSongs(area: NewestArea = .all) async throws -> [NewestSongDTO] {
         return try await withCheckedThrowingContinuation { continuation in
             NetworkProvider<HomeAPI>.request(
                 .fetchNewest(area),

--- a/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
@@ -1,0 +1,8 @@
+//
+//  HomeService.swift
+//  Melon_iOS
+//
+//  Created by 이승준 on 11/24/25.
+//
+
+import Foundation

--- a/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
@@ -10,7 +10,7 @@ import Foundation
 final class HomeService {
     
     func fetchPopularSongs() async throws -> [PopularSongDTO] {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             NetworkProvider<HomeAPI>.request(
                 .fetchPopular,
                 type: [PopularSongDTO].self
@@ -26,7 +26,7 @@ final class HomeService {
     }
     
     func fetchNewestSongs(area: NewestArea = .all) async throws -> [NewestSongDTO] {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             NetworkProvider<HomeAPI>.request(
                 .fetchNewest(area),
                 type: [NewestSongDTO].self
@@ -42,7 +42,7 @@ final class HomeService {
     }
     
     func fetchChartSongs() async throws -> [ChartSongDTO] {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             NetworkProvider<HomeAPI>.request(
                 .fetchChart,
                 type: [ChartSongDTO].self

--- a/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
@@ -6,3 +6,55 @@
 //
 
 import Foundation
+
+final class HomeService {
+    
+    func fetchPopularSongs() async throws -> [PopularSongDTO] {
+        return try await withCheckedThrowingContinuation { continuation in
+            NetworkProvider<HomeAPI>.request(
+                .fetchPopular,
+                type: [PopularSongDTO].self
+            ) { result in
+                switch result {
+                case .success(let data):
+                   continuation.resume(returning: data)
+
+                case .failure(let error):
+                   continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    func fetchNewestSongs(area: NewestArea? = nil) async throws -> [NewestSongDTO] {
+        return try await withCheckedThrowingContinuation { continuation in
+            NetworkProvider<HomeAPI>.request(
+                .fetchNewest(area),
+                type: [NewestSongDTO].self
+            ) { result in
+                switch result {
+                case .success(let data):
+                    continuation.resume(returning: data)
+                case .failure(let error):
+                   continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    func fetchChartSongs() async throws -> [ChartSongDTO] {
+        return try await withCheckedThrowingContinuation { continuation in
+            NetworkProvider<HomeAPI>.request(
+                .fetchChart,
+                type: [ChartSongDTO].self
+            ) { result in
+                switch result {
+                case .success(let data):
+                    continuation.resume(returning: data)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/HomeService.swift
@@ -18,7 +18,6 @@ final class HomeService {
                 switch result {
                 case .success(let data):
                    continuation.resume(returning: data)
-
                 case .failure(let error):
                    continuation.resume(throwing: error)
                 }

--- a/Melon_iOS/Melon_iOS/Network/Service/MockHomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/MockHomeService.swift
@@ -12,27 +12,27 @@ extension MockPopularService {
     PopularSongDTO(
       title: "XOXZ",
       artistName: "IVE (아이브)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/41260/4126044.jpg",),
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/41260/4126044.jpg"),
     PopularSongDTO(
       title: "Blue Valentine",
       artistName: "NMIXX",
-      imageUrl: "https://image.bugsm.co.kr/album/images/130/41299/4129960.jpg?version=20251108012458",),
+      imageUrl: "https://image.bugsm.co.kr/album/images/130/41299/4129960.jpg?version=20251108012458"),
     PopularSongDTO(
       title: "FOCUS",
       artistName: "Hearts2Hearts(하츠투하츠)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/130/41289/4128980.jpg?version=20251022002830",),
+      imageUrl: "https://image.bugsm.co.kr/album/images/130/41289/4128980.jpg?version=20251022002830"),
     PopularSongDTO(
       title: "XOXZ",
       artistName: "IVE (아이브)",
-      imageUrl: "https://image.bugsm.co.kr/artist/images/1000/201589/20158908.jpg?version=335304&d=20251021140549",),
+      imageUrl: "https://image.bugsm.co.kr/artist/images/1000/201589/20158908.jpg?version=335304&d=20251021140549"),
     PopularSongDTO(
       title: "Blue Valentine",
       artistName: "NMIXX",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/5297/529710.jpg",),
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/5297/529710.jpg"),
     PopularSongDTO(
       title: "FOCUS",
       artistName: "Hearts2Hearts(하츠투하츠)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg",),
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg"),
   ]
 }
 

--- a/Melon_iOS/Melon_iOS/Network/Service/MockHomeService.swift
+++ b/Melon_iOS/Melon_iOS/Network/Service/MockHomeService.swift
@@ -11,72 +11,66 @@ extension MockPopularService {
   static let mockData: [PopularSongDTO] = [
     PopularSongDTO(
       title: "XOXZ",
-      artist: "IVE (아이브)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/41260/4126044.jpg",
-      category: "멜론DJ's Pick"),
+      artistName: "IVE (아이브)",
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/41260/4126044.jpg",),
     PopularSongDTO(
       title: "Blue Valentine",
-      artist: "NMIXX",
-      imageUrl: "https://image.bugsm.co.kr/album/images/130/41299/4129960.jpg?version=20251108012458",
-      category: "검색 트렌드"),
+      artistName: "NMIXX",
+      imageUrl: "https://image.bugsm.co.kr/album/images/130/41299/4129960.jpg?version=20251108012458",),
     PopularSongDTO(
       title: "FOCUS",
-      artist: "Hearts2Hearts(하츠투하츠)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/130/41289/4128980.jpg?version=20251022002830",
-      category: "HOT100 7위"),
+      artistName: "Hearts2Hearts(하츠투하츠)",
+      imageUrl: "https://image.bugsm.co.kr/album/images/130/41289/4128980.jpg?version=20251022002830",),
     PopularSongDTO(
       title: "XOXZ",
-      artist: "IVE (아이브)",
-      imageUrl: "https://image.bugsm.co.kr/artist/images/1000/201589/20158908.jpg?version=335304&d=20251021140549",
-      category: "멜론DJ's Pick"),
+      artistName: "IVE (아이브)",
+      imageUrl: "https://image.bugsm.co.kr/artist/images/1000/201589/20158908.jpg?version=335304&d=20251021140549",),
     PopularSongDTO(
       title: "Blue Valentine",
-      artist: "NMIXX",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/5297/529710.jpg",
-      category: "검색 트렌드"),
+      artistName: "NMIXX",
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/5297/529710.jpg",),
     PopularSongDTO(
       title: "FOCUS",
-      artist: "Hearts2Hearts(하츠투하츠)",
-      imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg",
-      category: "HOT100 7위"),
+      artistName: "Hearts2Hearts(하츠투하츠)",
+      imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg",),
   ]
 }
 
 final class MockLatestService { }
 
 extension MockLatestService {
-  static let mockData: [LatestSongDTO] = [
-    LatestSongDTO(
+  static let mockData: [NewestSongDTO] = [
+    NewestSongDTO(
       title: "Back to Life",
-      artist: "&TEAM",
+      artistName: "&TEAM",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41316/4131671.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "마지막 약속",
-      artist: "김나영",
+      artistName: "김나영",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41317/4131700.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "Reno (Feat. Colde)",
-      artist: "미연 (MIYEON)",
+      artistName: "미연 (MIYEON)",
       imageUrl: "https://www.chosun.com/resizer/v2/ZDICNHHWZ6OAGZNCJGH3TBU6XY.jpg?auth=7373a524c2b6bec81926515e9315ce2f4d2c6b4ae27f2b268b7b28abb2adb7aa&width=464"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "X",
-      artist: "키코 (Kiko5o)",
+      artistName: "키코 (Kiko5o)",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41317/4131733.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "Omnibus",
-      artist: "장한음",
+      artistName: "장한음",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41317/4131704.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "CAPPUCCINO",
-      artist: "규빈 (GYUBIN)",
+      artistName: "규빈 (GYUBIN)",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41316/4131679.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title:"Milk Choco Quik",
-      artist: "리오 (RIO)",
+      artistName: "리오 (RIO)",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/207634/20763487.jpg"),
-    LatestSongDTO(
+    NewestSongDTO(
       title: "Last Dance",
-      artist: "몽니",
+      artistName: "몽니",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/207647/20764770.jpg"),
   ]
 }
@@ -87,35 +81,35 @@ extension MockChartService {
   static let mockData: [ChartSongDTO] = [
     ChartSongDTO(
       title: "Blue Valentine",
-      artist: "NMIXX",
+      artistName: "NMIXX",
       imageUrl: "https://image.bugsm.co.kr/album/images/130/41299/4129960.jpg?version=20251108012458"),
     ChartSongDTO(
       title: "타임캡슐",
-      artist: "다비치",
+      artistName: "다비치",
       imageUrl: "https://image.bugsm.co.kr/album/images/200/41306/4130608.jpg?version=20251017015619"),
     ChartSongDTO(
       title: "Golden",
-      artist: "HUNTR/X, EJAE, AUDREY NUNA, REI AMI",
+      artistName: "HUNTR/X, EJAE, AUDREY NUNA, REI AMI",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/381763/38176338.jpg?version=20250927005933"),
     ChartSongDTO(
       title: "Good Goodbye",
-      artist: "화사 (HWASA)",
+      artistName: "화사 (HWASA)",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg"),
     ChartSongDTO(
       title: "Drowning",
-      artist: "WOODZ",
+      artistName: "WOODZ",
       imageUrl: "https://image.bugsm.co.kr/album/images/200/40839/4083984.jpg?version=20250315015832"),
     ChartSongDTO(
       title: "뛰어(JUMP)",
-      artist: "BLACKPINK",
+      artistName: "BLACKPINK",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41229/4122947.jpg"),
     ChartSongDTO(
       title: "Good Goodbye",
-      artist: "화사 (HWASA)",
+      artistName: "화사 (HWASA)",
       imageUrl: "https://image.bugsm.co.kr/album/images/170/41305/4130508.jpg"),
     ChartSongDTO(
       title: "어제보다 슬픈 오늘",
-      artist: "우디 (Woody)",
+      artistName: "우디 (Woody)",
       imageUrl: "https://image.bugsm.co.kr/album/images/200/41171/4117180.jpg?version=20250710002336"),
   ]
 }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/Cells/ChartItemCell.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/Cells/ChartItemCell.swift
@@ -106,7 +106,7 @@ final class ChartItemCell: BaseUICollectionViewCell, ReuseIdentifiable {
   func configure(_ data: ChartSongDTO, row rank: Int = -1) {
     rankLabel.text = "\(rank + 1)"
     titleLabel.text = data.title
-    artistLabel.text = data.artist
+    artistLabel.text = data.artistName
     
     if let imageUrl = data.imageUrl, let url = URL(string: imageUrl) {
       imageView.kf.setImage(

--- a/Melon_iOS/Melon_iOS/Presentation/Home/Cells/LatestSongItemCell.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/Cells/LatestSongItemCell.swift
@@ -11,80 +11,80 @@ import SnapKit
 import Then
 
 final class LatestSongItemCell: BaseUICollectionViewCell, ReuseIdentifiable {
-  
-  // MARK: - UI Components
-  
-  private let imageView = UIImageView().then {
-    $0.contentMode = .scaleAspectFill
-    $0.clipsToBounds = true
-    $0.backgroundColor = .background2
-    $0.layer.cornerRadius = 4
-  }
-  
-  private let playButton = UIButton().then {
-    $0.contentMode = .scaleAspectFit
-    $0.setImage(.icPlay24, for: .normal)
-    $0.setImage(.icPause24, for: .selected)
-  }
-  
-  private let titleLabel = UILabel().then {
-    $0.font = UIFont.pretendard(.body_m_14)
-    $0.textColor = .white
-    $0.numberOfLines = 2
-  }
-  
-  private let artistLabel = UILabel().then {
-    $0.font = UIFont.pretendard(.caption_m_10)
-    $0.textColor = .gray200
-    $0.numberOfLines = 1
-  }
-  
-  // MARK: - Setup Methods
-  
-  override func setUI() {
-    playButton.addTarget(self, action: #selector(playButtonTapped), for: .touchUpInside)
     
-    addSubviews(imageView, playButton, titleLabel, artistLabel)
-  }
-  
-  override func setLayout() {
-    imageView.snp.makeConstraints {
-      $0.top.horizontalEdges.equalToSuperview()
-      $0.height.equalTo(imageView.snp.width)
+    // MARK: - UI Components
+    
+    private let imageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.backgroundColor = .background2
+        $0.layer.cornerRadius = 4
     }
     
-    playButton.snp.makeConstraints {
-      $0.size.equalTo(32)
-      $0.top.trailing.equalTo(imageView)
+    private let playButton = UIButton().then {
+        $0.contentMode = .scaleAspectFit
+        $0.setImage(.icPlay24, for: .normal)
+        $0.setImage(.icPause24, for: .selected)
     }
     
-    titleLabel.snp.makeConstraints {
-      $0.top.equalTo(imageView.snp.bottom).offset(4)
-      $0.horizontalEdges.equalToSuperview()
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont.pretendard(.body_m_14)
+        $0.textColor = .white
+        $0.numberOfLines = 2
     }
     
-    artistLabel.snp.makeConstraints {
-      $0.top.equalTo(titleLabel.snp.bottom).offset(2)
-      $0.horizontalEdges.equalToSuperview()
+    private let artistLabel = UILabel().then {
+        $0.font = UIFont.pretendard(.caption_m_10)
+        $0.textColor = .gray200
+        $0.numberOfLines = 1
     }
-  }
-  
-  // MARK: - Actions
-  
-  @objc private func playButtonTapped() {
-    playButton.isSelected.toggle()
-  }
-  
-  func configure(_ data: LatestSongDTO) {
-    titleLabel.text = data.title
-    artistLabel.text = data.artist
+    
+    // MARK: - Setup Methods
+    
+    override func setUI() {
+        playButton.addTarget(self, action: #selector(playButtonTapped), for: .touchUpInside)
         
-    if let imageUrl = data.imageUrl, let url = URL(string: imageUrl) {
-      imageView.kf.setImage(
-        with: url,
-        placeholder: .none,
-      )} else {
-        imageView.image = .none
-      }
-  }
+        addSubviews(imageView, playButton, titleLabel, artistLabel)
+    }
+    
+    override func setLayout() {
+        imageView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(imageView.snp.width)
+        }
+        
+        playButton.snp.makeConstraints {
+            $0.size.equalTo(32)
+            $0.top.trailing.equalTo(imageView)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.bottom).offset(4)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        artistLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(2)
+            $0.horizontalEdges.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func playButtonTapped() {
+        playButton.isSelected.toggle()
+    }
+    
+    func configure(_ data: NewestSongDTO) {
+        titleLabel.text = data.title
+        artistLabel.text = data.artistName
+        
+        if let imageUrl = data.imageUrl, let url = URL(string: imageUrl) {
+            imageView.kf.setImage(
+                with: url,
+                placeholder: .none,
+            )} else {
+                imageView.image = .none
+            }
+    }
 }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/Cells/PopularItemCell.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/Cells/PopularItemCell.swift
@@ -83,10 +83,19 @@ final class PopularItemCell: BaseUICollectionViewCell, ReuseIdentifiable {
     action!()
   }
   
-  func configure(_ data: PopularSongDTO, action: (() -> Void)? = nil) {
+    func configure(_ data: PopularSongDTO, indexPath: IndexPath ,action: (() -> Void)? = nil) {
     titleLabel.text = data.title
-    artistLabel.text = data.artist
-    categoryLabel.text = data.category
+    artistLabel.text = data.artistName
+        switch indexPath.row % 3 {
+        case 0:
+            categoryLabel.text = "멜론DJ’s Pick"
+        case 1:
+            categoryLabel.text = "검색 트렌드"
+        case 2:
+            categoryLabel.text = "HOT100 7위"
+        default :
+            return
+        }
     
     if let imageUrl = data.imageUrl, let url = URL(string: imageUrl) {
       imageView.kf.setImage(

--- a/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
@@ -145,11 +145,12 @@ extension HomeViewController: UICollectionViewDataSource {
                 toast.configure(action: {
                     let mixUp = MixUpViewController()
                     
-                    let transition = CATransition()
-                    transition.duration = 0.3
-                    transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                    transition.type = .moveIn
-                    transition.subtype = .fromTop
+                    let transition = CATransition().then {
+                        $0.duration = 0.3
+                        $0.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                        $0.type = .moveIn
+                        $0.subtype = .fromTop
+                    }
                     
                     self?.navigationController?.view.layer.add(transition, forKey: nil)
                     self?.navigationController?.pushViewController(mixUp, animated: false)

--- a/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
@@ -43,10 +43,7 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
         homeView.collectionView.headerRegister(LatestSectionHeader.self)
         homeView.collectionView.headerRegister(ChartSectionHeader.self)
         homeView.collectionView.footerRegister(ButtonSectionFooter.self)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        
         Task {
             try await fetchData()
         }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
@@ -43,7 +43,10 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
         homeView.collectionView.headerRegister(LatestSectionHeader.self)
         homeView.collectionView.headerRegister(ChartSectionHeader.self)
         homeView.collectionView.footerRegister(ButtonSectionFooter.self)
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         Task {
             try await fetchData()
         }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
@@ -10,189 +10,236 @@
 import UIKit
 
 final class HomeViewController: UIViewController, UICollectionViewDelegate {
-  
-  let homeView = HomeView()
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    self.view.backgroundColor = .background
-    self.view = homeView
     
-    homeView.collectionView.delegate = self
-    homeView.collectionView.dataSource = self
+    // MARK: - Properties
     
-    // Collection Cell 등록
-    homeView.collectionView.cellRegister(NavigationItemCell.self)
-    homeView.collectionView.cellRegister(PreferenceItemCell.self)
-    homeView.collectionView.cellRegister(PersonalizedItemCell.self)
-    homeView.collectionView.cellRegister(PopularItemCell.self)
-    homeView.collectionView.cellRegister(BannerItemCell.self)
-    homeView.collectionView.cellRegister(LatestSongItemCell.self)
-    homeView.collectionView.cellRegister(ChartItemCell.self)
+    private let homeView = HomeView()
+    private let service = HomeService()
+    private var popularSongList: [PopularSongDTO] = []
+    private var newestSongList: [NewestSongDTO] = []
+    private var chartSongList: [ChartSongDTO] = []
     
-    // Section Header 등록
-    homeView.collectionView.headerRegister(BasicSectionHeader.self)
-    homeView.collectionView.headerRegister(LatestSectionHeader.self)
-    homeView.collectionView.headerRegister(ChartSectionHeader.self)
+    // MARK: - Lifecycle
     
-    // Section Footer 등록
-    homeView.collectionView.footerRegister(ButtonSectionFooter.self)
-  }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .background
+        self.view = homeView
+        
+        homeView.collectionView.delegate = self
+        homeView.collectionView.dataSource = self
+        
+        // Collection Cell 등록
+        homeView.collectionView.cellRegister(NavigationItemCell.self)
+        homeView.collectionView.cellRegister(PreferenceItemCell.self)
+        homeView.collectionView.cellRegister(PersonalizedItemCell.self)
+        homeView.collectionView.cellRegister(PopularItemCell.self)
+        homeView.collectionView.cellRegister(BannerItemCell.self)
+        homeView.collectionView.cellRegister(LatestSongItemCell.self)
+        homeView.collectionView.cellRegister(ChartItemCell.self)
+        
+        // Section Header & Footer 등록
+        homeView.collectionView.headerRegister(BasicSectionHeader.self)
+        homeView.collectionView.headerRegister(LatestSectionHeader.self)
+        homeView.collectionView.headerRegister(ChartSectionHeader.self)
+        homeView.collectionView.footerRegister(ButtonSectionFooter.self)
+        
+        Task {
+            try await fetchData()
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func fetchData() async throws {
+        Task {
+            do {
+                self.popularSongList = try await service.fetchPopularSongs()
+                await MainActor.run {
+                    self.homeView.collectionView.reloadData()
+                }
+            } catch {
+                print("❌ Fetch Popular API 응답 오류:", error)
+            }
+        }
+        
+        Task {
+            do {
+                self.newestSongList = try await service.fetchNewestSongs()
+                await MainActor.run {
+                    self.homeView.collectionView.reloadData()
+                }
+            } catch {
+                print("❌ Fetch Newest API 응답 오류:", error)
+            }
+        }
+        
+        Task {
+            do {
+                self.chartSongList = try await service.fetchChartSongs()
+                await MainActor.run {
+                    self.homeView.collectionView.reloadData()
+                }
+            } catch {
+                print("❌ Fetch Chart API 응답 오류:", error)
+            }
+        }
+    }
 }
 
 extension HomeViewController: UICollectionViewDataSource {
-  
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return SectionType.allCases.count
-  }
-  
-  func collectionView(
-    _ collectionView: UICollectionView,
-    numberOfItemsInSection section: Int) -> Int {
     
-    guard let sectionType = SectionType(rawValue: section) else {
-      return 0
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return SectionType.allCases.count
     }
     
-    switch sectionType {
-    case .navigation: return 1
-    case .preference: return 1
-    case .personalized: return MockPersonalizedService.mockData.count
-    case .popular: return MockPopularService.mockData.count
-    case .banner: return MockBannerService.mockData.count
-    case .latest: return MockLatestService.mockData.count
-    case .chart: return MockChartService.mockData.count
-    }
-  }
-  
-  func collectionView(
-    _ collectionView: UICollectionView,
-    cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    
-    guard let sectionType = SectionType(rawValue: indexPath.section) else {
-      fatalError("Invalid section index")
-    }
-    
-    // 섹션 타입에 따라 다른 셀을 사용하도록 분기
-    switch sectionType {
-    case .navigation:
-      return collectionView.dequeueReusableCell(NavigationItemCell.self, for: indexPath)
-    case .preference:
-      let cell = collectionView.dequeueReusableCell(PreferenceItemCell.self, for: indexPath)
-      cell.configure()
-      return cell
-    case .personalized:
-      let cell = collectionView.dequeueReusableCell(PersonalizedItemCell.self, for: indexPath)
-      cell.configure(data: MockPersonalizedService.mockData[indexPath.row])
-      return cell
-    case .popular:
-      let cell = collectionView.dequeueReusableCell(PopularItemCell.self, for: indexPath)
-      cell.configure(MockPopularService.mockData[indexPath.row]) { [weak self] in
-        let toast = ToastMessage()
-          self?.homeView.addSubview(toast)
-          toast.configure(action: {
-              let mixUp = MixUpViewController()
-              self?.navigationController?.pushViewController(mixUp, animated: true)
-          })
-          toast.show()
-      }
-      return cell
-    case .banner:
-      let cell = collectionView.dequeueReusableCell(BannerItemCell.self, for: indexPath)
-      cell.configure(MockBannerService.mockData[indexPath.row])
-      return cell
-    case .latest:
-      let cell = collectionView.dequeueReusableCell(LatestSongItemCell.self, for: indexPath)
-      cell.configure(MockLatestService.mockData[indexPath.row])
-      return cell
-    case .chart:
-      let cell = collectionView.dequeueReusableCell(ChartItemCell.self, for: indexPath)
-      cell.configure(MockChartService.mockData[indexPath.row], row: indexPath.row)
-      return cell
-    }
-  }
-  
-  // 섹션 타입에 따라 Header와 Footer 등록
-  func collectionView(
-    _ collectionView: UICollectionView,
-    viewForSupplementaryElementOfKind kind: String,
-    at indexPath: IndexPath) -> UICollectionReusableView {
-    
-    guard let sectionType = SectionType(rawValue: indexPath.section) else {
-      fatalError("Invalid section index")
-    }
-    
-    switch sectionType {
-    case .personalized:
-      if kind == UICollectionView.elementKindSectionHeader {
-        guard let header = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
-          for: indexPath
-        ) as? BasicSectionHeader else {
-          fatalError("Cannot dequeue PersonalizedSectionHeader")
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int) -> Int {
+
+        guard let sectionType = SectionType(rawValue: section) else {
+            return 0
         }
-        header.configure(title: "닉네임을 위한 추천")
-        return header
-      }
-    case .popular:
-      if kind == UICollectionView.elementKindSectionHeader {
-        guard let header = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
-          for: indexPath
-        ) as? BasicSectionHeader else {
-          fatalError("Cannot dequeue PopularSectionHeader")
+
+        switch sectionType {
+        case .navigation: return 1
+        case .preference: return 1
+        case .personalized: return MockPersonalizedService.mockData.count
+        case .popular: return popularSongList.count
+        case .banner: return MockBannerService.mockData.count
+        case .latest: return newestSongList.count
+        case .chart: return chartSongList.count
         }
-        header.configure(title: "인기 선곡")
-        return header
-      }
-    case .latest:
-      if kind == UICollectionView.elementKindSectionHeader {
-        guard let header = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          withReuseIdentifier: LatestSectionHeader.reuseIdentifier,
-          for: indexPath
-        ) as? LatestSectionHeader else {
-          fatalError("Cannot dequeue LatestSectionHeader")
-        }
-        header.configure(action: { type in // API 호출 코드 작성
-          switch type {
-          case .all:
-            print("모든 곡이 선택되었습니다.")
-          case .domestic:
-            print("국내 곡이 선택되었습니다.")
-          case .overseas:
-            print("해외 곡이 선택되었습니다.")
-          }
-        })
-        return header
-      }
-    case .chart:
-      if kind == UICollectionView.elementKindSectionHeader {
-        guard let header = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          withReuseIdentifier: ChartSectionHeader.reuseIdentifier,
-          for: indexPath
-        ) as? ChartSectionHeader else {
-            fatalError("Cannot dequeue ChartSectionHeader")
-        }
-        return header
-      } else if kind == UICollectionView.elementKindSectionFooter {
-        guard let footer = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          withReuseIdentifier: ButtonSectionFooter.reuseIdentifier,
-          for: indexPath
-        ) as? ButtonSectionFooter else {
-          fatalError("Cannot dequeue ChartSectionFooter")
-        }
-        footer.configure(title: "TOP 100 전체듣기")
-        return footer
-      }
-    default:
-        fatalError("No such Reusable View")
     }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            
+            guard let sectionType = SectionType(rawValue: indexPath.section) else {
+                fatalError("Invalid section index")
+            }
+
+            switch sectionType {
+            case .navigation:
+                return collectionView.dequeueReusableCell(NavigationItemCell.self, for: indexPath)
+            case .preference:
+                let cell = collectionView.dequeueReusableCell(PreferenceItemCell.self, for: indexPath)
+                cell.configure()
+                return cell
+            case .personalized:
+                let cell = collectionView.dequeueReusableCell(PersonalizedItemCell.self, for: indexPath)
+                cell.configure(data: MockPersonalizedService.mockData[indexPath.row])
+                return cell
+            case .popular:
+                let cell = collectionView.dequeueReusableCell(PopularItemCell.self, for: indexPath)
+                cell.configure(popularSongList[indexPath.row], indexPath: indexPath)
+                { [weak self] in
+                    let toast = ToastMessage()
+                    self?.homeView.addSubview(toast)
+                    toast.configure(action: {
+                        let mixUp = MixUpViewController()
+                        self?.navigationController?.pushViewController(mixUp, animated: true)
+                    })
+                    toast.show()
+                }
+                return cell
+            case .banner:
+                let cell = collectionView.dequeueReusableCell(BannerItemCell.self, for: indexPath)
+                cell.configure(MockBannerService.mockData[indexPath.row])
+                return cell
+            case .latest:
+                let cell = collectionView.dequeueReusableCell(LatestSongItemCell.self, for: indexPath)
+                cell.configure(newestSongList[indexPath.row])
+                return cell
+            case .chart:
+                let cell = collectionView.dequeueReusableCell(ChartItemCell.self, for: indexPath)
+                cell.configure(chartSongList[indexPath.row], row: indexPath.row)
+                return cell
+            }
+        }
     
-    fatalError("Missing supplementary view logic for kind: \(kind)")
-  }
+    // 섹션 타입에 따라 Header와 Footer 등록
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath) -> UICollectionReusableView {
+            
+            guard let sectionType = SectionType(rawValue: indexPath.section) else {
+                fatalError("Invalid section index")
+            }
+            
+            switch sectionType {
+            case .personalized:
+                if kind == UICollectionView.elementKindSectionHeader {
+                    guard let header = collectionView.dequeueReusableSupplementaryView(
+                        ofKind: kind,
+                        withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
+                        for: indexPath
+                    ) as? BasicSectionHeader else {
+                        fatalError("Cannot dequeue PersonalizedSectionHeader")
+                    }
+                    header.configure(title: "닉네임을 위한 추천")
+                    return header
+                }
+            case .popular:
+                if kind == UICollectionView.elementKindSectionHeader {
+                    guard let header = collectionView.dequeueReusableSupplementaryView(
+                        ofKind: kind,
+                        withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
+                        for: indexPath
+                    ) as? BasicSectionHeader else {
+                        fatalError("Cannot dequeue PopularSectionHeader")
+                    }
+                    header.configure(title: "인기 선곡")
+                    return header
+                }
+            case .latest:
+                if kind == UICollectionView.elementKindSectionHeader {
+                    guard let header = collectionView.dequeueReusableSupplementaryView(
+                        ofKind: kind,
+                        withReuseIdentifier: LatestSectionHeader.reuseIdentifier,
+                        for: indexPath
+                    ) as? LatestSectionHeader else {
+                        fatalError("Cannot dequeue LatestSectionHeader")
+                    }
+                    header.configure(action: { type in // API 호출 코드 작성
+                        Task {
+                            do {
+                                self.newestSongList = try await self.service.fetchNewestSongs(area: type)
+                                collectionView.reloadData()
+                            } catch {
+                                print("❌ Newest \(type.rawValue) API 응답 오류:", error)
+                            }
+                        }
+                    })
+                    return header
+                }
+            case .chart:
+                if kind == UICollectionView.elementKindSectionHeader {
+                    guard let header = collectionView.dequeueReusableSupplementaryView(
+                        ofKind: kind,
+                        withReuseIdentifier: ChartSectionHeader.reuseIdentifier,
+                        for: indexPath
+                    ) as? ChartSectionHeader else {
+                        fatalError("Cannot dequeue ChartSectionHeader")
+                    }
+                    return header
+                } else if kind == UICollectionView.elementKindSectionFooter {
+                    guard let footer = collectionView.dequeueReusableSupplementaryView(
+                        ofKind: kind,
+                        withReuseIdentifier: ButtonSectionFooter.reuseIdentifier,
+                        for: indexPath
+                    ) as? ButtonSectionFooter else {
+                        fatalError("Cannot dequeue ChartSectionFooter")
+                    }
+                    footer.configure(title: "TOP 100 전체듣기")
+                    return footer
+                }
+            default:
+                fatalError("No such Reusable View")
+            }
+            
+            fatalError("Missing supplementary view logic for kind: \(kind)")
+        }
 }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/HomeViewController.swift
@@ -87,6 +87,8 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
     }
 }
 
+// MARK: - Extension UICollectionViewDataSource
+
 extension HomeViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -116,48 +118,56 @@ extension HomeViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
             
-            guard let sectionType = SectionType(rawValue: indexPath.section) else {
-                fatalError("Invalid section index")
-            }
-
-            switch sectionType {
-            case .navigation:
-                return collectionView.dequeueReusableCell(NavigationItemCell.self, for: indexPath)
-            case .preference:
-                let cell = collectionView.dequeueReusableCell(PreferenceItemCell.self, for: indexPath)
-                cell.configure()
-                return cell
-            case .personalized:
-                let cell = collectionView.dequeueReusableCell(PersonalizedItemCell.self, for: indexPath)
-                cell.configure(data: MockPersonalizedService.mockData[indexPath.row])
-                return cell
-            case .popular:
-                let cell = collectionView.dequeueReusableCell(PopularItemCell.self, for: indexPath)
-                cell.configure(popularSongList[indexPath.row], indexPath: indexPath)
-                { [weak self] in
-                    let toast = ToastMessage()
-                    self?.homeView.addSubview(toast)
-                    toast.configure(action: {
-                        let mixUp = MixUpViewController()
-                        self?.navigationController?.pushViewController(mixUp, animated: true)
-                    })
-                    toast.show()
-                }
-                return cell
-            case .banner:
-                let cell = collectionView.dequeueReusableCell(BannerItemCell.self, for: indexPath)
-                cell.configure(MockBannerService.mockData[indexPath.row])
-                return cell
-            case .latest:
-                let cell = collectionView.dequeueReusableCell(LatestSongItemCell.self, for: indexPath)
-                cell.configure(newestSongList[indexPath.row])
-                return cell
-            case .chart:
-                let cell = collectionView.dequeueReusableCell(ChartItemCell.self, for: indexPath)
-                cell.configure(chartSongList[indexPath.row], row: indexPath.row)
-                return cell
-            }
+        guard let sectionType = SectionType(rawValue: indexPath.section) else {
+            fatalError("Invalid section index")
         }
+
+        switch sectionType {
+        case .navigation:
+            return collectionView.dequeueReusableCell(NavigationItemCell.self, for: indexPath)
+        case .preference:
+            let cell = collectionView.dequeueReusableCell(PreferenceItemCell.self, for: indexPath)
+            cell.configure()
+            return cell
+        case .personalized:
+            let cell = collectionView.dequeueReusableCell(PersonalizedItemCell.self, for: indexPath)
+            cell.configure(data: MockPersonalizedService.mockData[indexPath.row])
+            return cell
+        case .popular:
+            let cell = collectionView.dequeueReusableCell(PopularItemCell.self, for: indexPath)
+            cell.configure(popularSongList[indexPath.row], indexPath: indexPath)
+            { [weak self] in
+                let toast = ToastMessage()
+                self?.homeView.addSubview(toast)
+                toast.configure(action: {
+                    let mixUp = MixUpViewController()
+                    
+                    let transition = CATransition()
+                    transition.duration = 0.3
+                    transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                    transition.type = .moveIn
+                    transition.subtype = .fromTop
+                    
+                    self?.navigationController?.view.layer.add(transition, forKey: nil)
+                    self?.navigationController?.pushViewController(mixUp, animated: false)
+                })
+                toast.show()
+            }
+            return cell
+        case .banner:
+            let cell = collectionView.dequeueReusableCell(BannerItemCell.self, for: indexPath)
+            cell.configure(MockBannerService.mockData[indexPath.row])
+            return cell
+        case .latest:
+            let cell = collectionView.dequeueReusableCell(LatestSongItemCell.self, for: indexPath)
+            cell.configure(newestSongList[indexPath.row])
+            return cell
+        case .chart:
+            let cell = collectionView.dequeueReusableCell(ChartItemCell.self, for: indexPath)
+            cell.configure(chartSongList[indexPath.row], row: indexPath.row)
+            return cell
+        }
+    }
     
     // 섹션 타입에 따라 Header와 Footer 등록
     func collectionView(
@@ -165,81 +175,81 @@ extension HomeViewController: UICollectionViewDataSource {
         viewForSupplementaryElementOfKind kind: String,
         at indexPath: IndexPath) -> UICollectionReusableView {
             
-            guard let sectionType = SectionType(rawValue: indexPath.section) else {
-                fatalError("Invalid section index")
-            }
-            
-            switch sectionType {
-            case .personalized:
-                if kind == UICollectionView.elementKindSectionHeader {
-                    guard let header = collectionView.dequeueReusableSupplementaryView(
-                        ofKind: kind,
-                        withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
-                        for: indexPath
-                    ) as? BasicSectionHeader else {
-                        fatalError("Cannot dequeue PersonalizedSectionHeader")
-                    }
-                    header.configure(title: "닉네임을 위한 추천")
-                    return header
-                }
-            case .popular:
-                if kind == UICollectionView.elementKindSectionHeader {
-                    guard let header = collectionView.dequeueReusableSupplementaryView(
-                        ofKind: kind,
-                        withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
-                        for: indexPath
-                    ) as? BasicSectionHeader else {
-                        fatalError("Cannot dequeue PopularSectionHeader")
-                    }
-                    header.configure(title: "인기 선곡")
-                    return header
-                }
-            case .latest:
-                if kind == UICollectionView.elementKindSectionHeader {
-                    guard let header = collectionView.dequeueReusableSupplementaryView(
-                        ofKind: kind,
-                        withReuseIdentifier: LatestSectionHeader.reuseIdentifier,
-                        for: indexPath
-                    ) as? LatestSectionHeader else {
-                        fatalError("Cannot dequeue LatestSectionHeader")
-                    }
-                    header.configure(action: { type in // API 호출 코드 작성
-                        Task {
-                            do {
-                                self.newestSongList = try await self.service.fetchNewestSongs(area: type)
-                                collectionView.reloadData()
-                            } catch {
-                                print("❌ Newest \(type.rawValue) API 응답 오류:", error)
-                            }
-                        }
-                    })
-                    return header
-                }
-            case .chart:
-                if kind == UICollectionView.elementKindSectionHeader {
-                    guard let header = collectionView.dequeueReusableSupplementaryView(
-                        ofKind: kind,
-                        withReuseIdentifier: ChartSectionHeader.reuseIdentifier,
-                        for: indexPath
-                    ) as? ChartSectionHeader else {
-                        fatalError("Cannot dequeue ChartSectionHeader")
-                    }
-                    return header
-                } else if kind == UICollectionView.elementKindSectionFooter {
-                    guard let footer = collectionView.dequeueReusableSupplementaryView(
-                        ofKind: kind,
-                        withReuseIdentifier: ButtonSectionFooter.reuseIdentifier,
-                        for: indexPath
-                    ) as? ButtonSectionFooter else {
-                        fatalError("Cannot dequeue ChartSectionFooter")
-                    }
-                    footer.configure(title: "TOP 100 전체듣기")
-                    return footer
-                }
-            default:
-                fatalError("No such Reusable View")
-            }
-            
-            fatalError("Missing supplementary view logic for kind: \(kind)")
+        guard let sectionType = SectionType(rawValue: indexPath.section) else {
+            fatalError("Invalid section index")
         }
+        
+        switch sectionType {
+        case .personalized:
+            if kind == UICollectionView.elementKindSectionHeader {
+                guard let header = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
+                    for: indexPath
+                ) as? BasicSectionHeader else {
+                    fatalError("Cannot dequeue PersonalizedSectionHeader")
+                }
+                header.configure(title: "닉네임을 위한 추천")
+                return header
+            }
+        case .popular:
+            if kind == UICollectionView.elementKindSectionHeader {
+                guard let header = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: BasicSectionHeader.reuseIdentifier,
+                    for: indexPath
+                ) as? BasicSectionHeader else {
+                    fatalError("Cannot dequeue PopularSectionHeader")
+                }
+                header.configure(title: "인기 선곡")
+                return header
+            }
+        case .latest:
+            if kind == UICollectionView.elementKindSectionHeader {
+                guard let header = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: LatestSectionHeader.reuseIdentifier,
+                    for: indexPath
+                ) as? LatestSectionHeader else {
+                    fatalError("Cannot dequeue LatestSectionHeader")
+                }
+                header.configure(action: { type in // API 호출 코드 작성
+                    Task {
+                        do {
+                            self.newestSongList = try await self.service.fetchNewestSongs(area: type)
+                            collectionView.reloadData()
+                        } catch {
+                            print("❌ Newest \(type.rawValue) API 응답 오류:", error)
+                        }
+                    }
+                })
+                return header
+            }
+        case .chart:
+            if kind == UICollectionView.elementKindSectionHeader {
+                guard let header = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: ChartSectionHeader.reuseIdentifier,
+                    for: indexPath
+                ) as? ChartSectionHeader else {
+                    fatalError("Cannot dequeue ChartSectionHeader")
+                }
+                return header
+            } else if kind == UICollectionView.elementKindSectionFooter {
+                guard let footer = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: ButtonSectionFooter.reuseIdentifier,
+                    for: indexPath
+                ) as? ButtonSectionFooter else {
+                    fatalError("Cannot dequeue ChartSectionFooter")
+                }
+                footer.configure(title: "TOP 100 전체듣기")
+                return footer
+            }
+        default:
+            fatalError("No such Reusable View")
+        }
+        
+        fatalError("Missing supplementary view logic for kind: \(kind)")
+    }
 }

--- a/Melon_iOS/Melon_iOS/Presentation/Home/Sections/LatestSectionHeader.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/Sections/LatestSectionHeader.swift
@@ -12,7 +12,7 @@ import Then
 
 final class LatestSectionHeader: BaseUICollectionReusableView, ReuseIdentifiable {
   
-  // MARK: - Custom Type
+  // MARK: - Properties
     
   private var action: ((NewestArea) -> Void)?
   

--- a/Melon_iOS/Melon_iOS/Presentation/Home/Sections/LatestSectionHeader.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Home/Sections/LatestSectionHeader.swift
@@ -13,14 +13,8 @@ import Then
 final class LatestSectionHeader: BaseUICollectionReusableView, ReuseIdentifiable {
   
   // MARK: - Custom Type
-  
-  enum LatestMusicButtonType {
-    case all
-    case domestic
-    case overseas
-  }
-  
-  private var action: ((LatestMusicButtonType) -> Void)?
+    
+  private var action: ((NewestArea) -> Void)?
   
   // MARK: - UI Components
   
@@ -115,24 +109,24 @@ final class LatestSectionHeader: BaseUICollectionReusableView, ReuseIdentifiable
     allButon.isSelected = true
     domesticButton.isSelected = false
     overseasButton.isSelected = false
-    action!(.all)
+      action!(.all)
   }
   
   @objc private func didTapDomesticButton() {
     allButon.isSelected = false
     domesticButton.isSelected = true
     overseasButton.isSelected = false
-    action!(.domestic)
+      action!(.kor)
   }
   
   @objc private func didTapOverseasButton() {
     allButon.isSelected = false
     domesticButton.isSelected = false
     overseasButton.isSelected = true
-    action!(.overseas)
+      action!(.int)
   }
   
-  func configure(action: ((LatestMusicButtonType) -> Void)? = nil) {
+  func configure(action: ((NewestArea) -> Void)? = nil) {
     self.action = action
   }
 }


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #38

---

## 📎 Work Description 
- Home API 연동
- MixUp 화면 전환시 위로 올라가게 구현

### Moya의 Task를 이용한 Query String 작성하기

**배경**

```
/api/v1/music/newest?category=KOR
```

위 URL처럼, ? 를 이용하여 Query String을 작성해야 했다. 하지만 실제로 요청을 보내면 아래와 같았다.

```
/api/v1/music/newest%3Fcategory=KOR
```

**원인**

Moya는 URL 안에 ? 같은 특수 기호는 인코딩한다. 따라서 ?를 쓰려면 `Task`를 써야 했다. (Swift Concurrency와 다른 Task 입니다.)

**해결**

파라미터를 Task에 위임하여 처리한다. Moya가 알아서 ?와 &를 붙여줌으로 객체를 생성해주면 된다.

``` swift
var task: Task {
    return .requestParameters(
        parameters: ["category": area.rawValue],
        encoding: URLEncoding.default
    )
}
```

- parameters는 딕셔너리 형태로 작성한다.

### Unsafe vs Checked

Checked는 런타임에 resume() 함수가 실행되지 않거나 여러번 실행되었는지 여부를 확인합니다. resume()은 반드시 한 번만 실행되어야 합니다. 그렇지 않으면 메모리 누수가 발생하기 때문이죠. Unsafe는 이런 검사를 진행하지 않기 때문에 오버헤드가 적고 빠른 실행이 가능합니다.

깊어가는 콩코론시 밤 스터디에서 배웠던 내용인데, Checked로 개발할 때, 안정성 테스트를 진행하고 배포할 때는 Unsafe로 바꿔서 성능상 이점을 얻는다고 배웠습니다. 생각나서 Checked에서 Unsafe로 바꿔봤습니다.

### CATransition

**배경**

믹스업 화면이 해제될 때, 아래로 내려가는 애니메이션으로 처리된다. 그렇다면, 처음 나올 때도 위로 나와야 맥락이 맞는거 같아서, push할 때, 위로 올라오게 애니메이션을 바꿔보았다.

**해결**

CATransition을 이용하면 방향을 전환할 수 있습니다. CA는 Core Animation의 약자로 이 프레임워크는 UIKit보다 낮은 수준에서 동작합니다. 따라서 최적화에 대한 이점을 얻을 수 있고 다른 UI 프레임워크에서도 동일하게 적용되어 적용되는 범위가 넓습니다. (UIKit, AppKit, SwiftUI)

CATransition은 Layer간 이동 시, 사용되는 객체입니다. (Layer는 Core Animation의 기본 단위로 매우 중요하나, 공부하다 이건 좀 아니다 싶어서 일단 CATransition만 설명하겠습니다... ㅠㅠ)

주요 프로퍼티를 설명하자면,

`duration: CFTimeInterval` : 애니메이션 시간
`timingFunction: CAMediaTimingFunction` : 애니메이션의 가속도를 결정
`type: CATransitionType` : 전환 효과 종류
`subtype: CATransitionSubType` : 전환효과가 시작되는 위치

```swift
let transition = CATransition().then {
    $0.duration = 0.3
    $0.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut) 
    $0.type = .moveIn
    $0.subtype = .fromTop
}

self?.navigationController?.view.layer.add(transition, forKey: nil) // UIView의 layer에 추가해주면 된다.
```

- .easeInEaseOut : 느리게 시작했다가 점점 빨라지고 다시 마지막에 느려지는 가속도 효과
- fromTop : 아래에서 올라오는데 위에서 시작하라고 지정한 이유는 AutoLayout에서 배웠던것 처럼 CALayer의 y축 좌표는 화면위에서 시작되기 때문입니다.
---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| 전체 API 연동 | ![11 all](https://github.com/user-attachments/assets/5915fc28-53cd-41c4-8046-41d4dd34df67) | ![17 all](https://github.com/user-attachments/assets/e4338060-5c42-4d9f-a3dc-d5f748575363) |
| 지역별 API 호출 | ![11 newest](https://github.com/user-attachments/assets/1721c6a8-7baa-44e9-a12b-daa676502ef8) | ![17,newest](https://github.com/user-attachments/assets/31f2b998-c15d-4ac7-870b-5501c13c9ecd) |
| 화면전환 방향 | ![11 transition](https://github.com/user-attachments/assets/cf354654-9d25-47fc-801e-b1d1ffd68b7b) | ![17 transition](https://github.com/user-attachments/assets/2282737d-938e-41b1-a3af-4f68c40cfa2a) |

---



## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
