### PR TITLE
[refactor] 전체 앱 루트 구조를 TabBar 기반으로 전환

### DIFF
--- a/Melon_iOS/Melon_iOS/Application/SceneDelegate.swift
+++ b/Melon_iOS/Melon_iOS/Application/SceneDelegate.swift
@@ -14,15 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-
         let window = UIWindow(windowScene: windowScene)
 
-        let rootVC = TabBarController()
-        let nav = UINavigationController(rootViewController: rootVC).then {
-            $0.isNavigationBarHidden = true
-        }
-
-        window.rootViewController = nav
+        window.rootViewController = TabBarController()
 
         window.makeKeyAndVisible()
         self.window = window
@@ -55,7 +49,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/Melon_iOS/Melon_iOS/Presentation/Core/TabBarController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/Core/TabBarController.swift
@@ -69,17 +69,23 @@ final class TabBarController: UITabBarController {
     
     private func setViewControllers() {
         let topMargin: CGFloat = 7.0
+            
         self.viewControllers = Tab.allCases.map { tab in
-            let vc = tab.viewController
+            let rootVC = tab.viewController
+            let nav = UINavigationController(rootViewController: rootVC)
+            nav.isNavigationBarHidden = true
             
             let icon = resizeImage(image: tab.imageName).withRenderingMode(.alwaysOriginal)
             let selectedIcon = resizeImage(image: tab.selectedImageName).withRenderingMode(.alwaysOriginal)
             
-            let tabBarItem = UITabBarItem(title: nil, image: icon, selectedImage: selectedIcon)
-            tabBarItem.tag = tab.rawValue
-            tabBarItem.imageInsets = UIEdgeInsets(top: topMargin, left: 0, bottom: -topMargin, right: 0)
-            vc.tabBarItem = tabBarItem
-            return vc
+            nav.tabBarItem = UITabBarItem(title: nil,
+                                          image: icon,
+                                          selectedImage: selectedIcon)
+            nav.tabBarItem.tag = tab.rawValue
+            nav.tabBarItem.imageInsets = UIEdgeInsets(top: topMargin, left: 0,
+                                                      bottom: -topMargin, right: 0)
+            
+            return nav
         }
     }
     
@@ -131,5 +137,3 @@ extension TabBarController: UITabBarControllerDelegate {
         }
     }
 }
-
-

--- a/Melon_iOS/Melon_iOS/Presentation/MixUp/MixUpViewController.swift
+++ b/Melon_iOS/Melon_iOS/Presentation/MixUp/MixUpViewController.swift
@@ -101,7 +101,8 @@ extension MixUpViewController: MixUpViewDelegate {
 
     func didTapChevronDown() {
 
-        if let tabBar = UIApplication.shared.windows.first?.rootViewController as? TabBarController {
+        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let tabBar = scene.windows.first?.rootViewController as? TabBarController {
             tabBar.selectedIndex = 0
         }
 


### PR DESCRIPTION
## ✅ Check List
- [ ] 팀원 전원의 Approve를 받은 후 머지해주세요.
- [ ] 변경 사항은 500줄 이내로 유지해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #51 

---

## 📎 Work Description
- 탭바가 네비게이션 컨트롤러 안에 들어있는 구조라서 tabBar.selectedIndex = 0 을 호출해도 실제 화면 전환보다
네비게이션 스택(pop/push) 이 먼저 적용되는 문제가 있었어요 ㅠ.ㅠ 
인덱스보다 이전 화면으로 돌아가는 동작(pop)이 우선되어 원하는 화면으로 이동하지 않았던 거죠!!! 
- 네비게이션 기반 루트를 제거하고 **TabBar 중심 구조로 재설계**했습니다.
- SceneDelegate에서 `UINavigationController`를 감싸지 않고 `TabBarController`를 직접 루트로 넣는 방식으로 바꿨어요!

### SceneDelegate

```swift
func scene(_ scene: UIScene,
           willConnectTo session: UISceneSession,
           options connectionOptions: UIScene.ConnectionOptions) {

    guard let windowScene = (scene as? UIWindowScene) else { return }

    let window = UIWindow(windowScene: windowScene)

    // 기존
    // let rootVC = TabBarController()
    // let nav = UINavigationController(rootViewController: rootVC)
    // window.rootViewController = nav

    // 변경 후
    let tabBar = TabBarController()
    window.rootViewController = tabBar

    window.makeKeyAndVisible()
    self.window = window
}
```

---

## 📷 Screenshots  

| 기능/화면 | iPhone 11 Pro | iPhone 16 Pro |
|:---------:|:--------------:|:--------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/f8225708-8acb-4fe9-899c-614bc7adee92" width="250"> | <img src="" width="250"> |

맥북 아파서 시뮬 돌리기 힘들다.. 11pro만 넣을래 봐줘 >_<❤️

---

## 💬 To Reviewers  
- 홈 → 믹스업, 포유 → 믹스업 이동 시 화면 전환 애니메이션 방식이 서로 달라서 통일하면 좋을 것 같아요! 홈꺼 홈쳐오자 ㅋㅋ